### PR TITLE
Allow string paths in user-facing path parameters

### DIFF
--- a/src/exstruct/__init__.py
+++ b/src/exstruct/__init__.py
@@ -307,8 +307,8 @@ def export_auto_page_breaks(
 
 
 def process_excel(
-    file_path: Path,
-    output_path: Path | None = None,
+    file_path: str | Path,
+    output_path: str | Path | None = None,
     out_fmt: str = "json",
     image: bool = False,
     pdf: bool = False,
@@ -316,17 +316,17 @@ def process_excel(
     mode: ExtractionMode = "standard",
     pretty: bool = False,
     indent: int | None = None,
-    sheets_dir: Path | None = None,
-    print_areas_dir: Path | None = None,
-    auto_page_breaks_dir: Path | None = None,
+    sheets_dir: str | Path | None = None,
+    print_areas_dir: str | Path | None = None,
+    auto_page_breaks_dir: str | Path | None = None,
     stream: TextIO | None = None,
 ) -> None:
     """
     Convenience wrapper: extract -> serialize (file or stdout) -> optional PDF/PNG.
 
     Args:
-        file_path: Input Excel workbook.
-        output_path: None for stdout; otherwise, write to file.
+        file_path: Input Excel workbook (path string or Path).
+        output_path: None for stdout; otherwise, write to file (string or Path).
         out_fmt: json/yaml/yml/toon.
         image: True to also output PNGs (requires Excel + COM + pypdfium2).
         pdf: True to also output PDF (requires Excel + COM + pypdfium2).
@@ -334,8 +334,8 @@ def process_excel(
         mode: light/standard/verbose (same meaning as `extract`).
         pretty: Pretty-print JSON.
         indent: JSON indent width.
-        sheets_dir: Directory to write per-sheet files.
-        print_areas_dir: Directory to write per-print-area files.
+        sheets_dir: Directory to write per-sheet files (string or Path).
+        print_areas_dir: Directory to write per-print-area files (string or Path).
         auto_page_breaks_dir: Directory to write per-auto-page-break files (COM only).
         stream: IO override when output_path is None.
 

--- a/src/exstruct/core/integrate.py
+++ b/src/exstruct/core/integrate.py
@@ -288,7 +288,7 @@ def integrate_sheet_content(
 
 
 def extract_workbook(  # noqa: C901
-    file_path: Path,
+    file_path: str | Path,
     mode: Literal["light", "standard", "verbose"] = "standard",
     *,
     include_cell_links: bool = False,
@@ -299,21 +299,23 @@ def extract_workbook(  # noqa: C901
     if mode not in _ALLOWED_MODES:
         raise ValueError(f"Unsupported mode: {mode}")
 
+    normalized_file_path = Path(file_path)
+
     cell_data = (
-        extract_sheet_cells_with_links(file_path)
+        extract_sheet_cells_with_links(normalized_file_path)
         if include_cell_links
-        else extract_sheet_cells(file_path)
+        else extract_sheet_cells(normalized_file_path)
     )
     print_area_data: dict[str, list[PrintArea]] = {}
     if include_print_areas:
-        print_area_data = _extract_print_areas_openpyxl(file_path)
+        print_area_data = _extract_print_areas_openpyxl(normalized_file_path)
     auto_page_break_data: dict[str, list[PrintArea]] = {}
 
     def _cells_and_tables_only(reason: str) -> WorkbookData:
         sheets: dict[str, SheetData] = {}
         for sheet_name, rows in cell_data.items():
             try:
-                tables = detect_tables_openpyxl(file_path, sheet_name)
+                tables = detect_tables_openpyxl(normalized_file_path, sheet_name)
             except Exception:
                 tables = []
             sheets[sheet_name] = SheetData(

--- a/src/exstruct/render/__init__.py
+++ b/src/exstruct/render/__init__.py
@@ -25,15 +25,17 @@ def _require_excel_app() -> xw.App:
         ) from e
 
 
-def export_pdf(excel_path: Path, output_pdf: Path) -> list[str]:
+def export_pdf(excel_path: str | Path, output_pdf: str | Path) -> list[str]:
     """Export an Excel workbook to PDF via Excel COM and return sheet names in order."""
-    output_pdf.parent.mkdir(parents=True, exist_ok=True)
+    normalized_excel_path = Path(excel_path)
+    normalized_output_pdf = Path(output_pdf)
+    normalized_output_pdf.parent.mkdir(parents=True, exist_ok=True)
 
     with tempfile.TemporaryDirectory() as td:
         temp_dir = Path(td)
         temp_xlsx = temp_dir / "book.xlsx"
         temp_pdf = temp_dir / "book.pdf"
-        shutil.copy(excel_path, temp_xlsx)
+        shutil.copy(normalized_excel_path, temp_xlsx)
 
         app: xw.App | None = None
         wb: xw.Book | None = None
@@ -42,20 +44,25 @@ def export_pdf(excel_path: Path, output_pdf: Path) -> list[str]:
             wb = app.books.open(str(temp_xlsx))
             sheet_names = [s.name for s in wb.sheets]
             wb.api.ExportAsFixedFormat(0, str(temp_pdf))
-            shutil.copy(temp_pdf, output_pdf)
+            shutil.copy(temp_pdf, normalized_output_pdf)
         except RenderError:
             raise
         except Exception as exc:
             raise RenderError(
-                f"Failed to export PDF for '{excel_path}' to '{output_pdf}'."
+                (
+                    "Failed to export PDF for "
+                    f"'{normalized_excel_path}' to '{normalized_output_pdf}'."
+                )
             ) from exc
         finally:
             if wb is not None:
                 wb.close()
             if app is not None:
                 app.quit()
-        if not output_pdf.exists():
-            raise RenderError(f"Failed to export PDF to '{output_pdf}'.")
+        if not normalized_output_pdf.exists():
+            raise RenderError(
+                f"Failed to export PDF to '{normalized_output_pdf}'."
+            )
     return sheet_names
 
 
@@ -71,16 +78,18 @@ def _require_pdfium() -> ModuleType:
 
 
 def export_sheet_images(
-    excel_path: Path, output_dir: Path, dpi: int = 144
+    excel_path: str | Path, output_dir: str | Path, dpi: int = 144
 ) -> list[Path]:
     """Export each sheet as PNG (via PDF then pypdfium2 rasterization) and return paths in sheet order."""
     pdfium = cast(Any, _require_pdfium())
-    output_dir.mkdir(parents=True, exist_ok=True)
+    normalized_excel_path = Path(excel_path)
+    normalized_output_dir = Path(output_dir)
+    normalized_output_dir.mkdir(parents=True, exist_ok=True)
 
     try:
         with tempfile.TemporaryDirectory() as td:
             tmp_pdf = Path(td) / "book.pdf"
-            sheet_names = export_pdf(excel_path, tmp_pdf)
+            sheet_names = export_pdf(normalized_excel_path, tmp_pdf)
 
             scale = dpi / 72.0
             written: list[Path] = []
@@ -90,14 +99,16 @@ def export_sheet_images(
                     bitmap = page.render(scale=scale)
                     pil_image = bitmap.to_pil()
                     safe_name = _sanitize_sheet_filename(sheet_name)
-                    img_path = output_dir / f"{i + 1:02d}_{safe_name}.png"
+                    img_path = normalized_output_dir / f"{i + 1:02d}_{safe_name}.png"
                     pil_image.save(img_path, format="PNG", dpi=(dpi, dpi))
                     written.append(img_path)
             return written
     except RenderError:
         raise
     except Exception as exc:
-        raise RenderError(f"Failed to export sheet images to '{output_dir}'.") from exc
+        raise RenderError(
+            f"Failed to export sheet images to '{normalized_output_dir}'."
+        ) from exc
 
 
 def _sanitize_sheet_filename(name: str) -> str:


### PR DESCRIPTION
## Summary
- accept string path inputs across user-facing APIs and normalize to Path internally
- add normalization helpers to ExStructEngine and propagate normalized paths through rendering utilities
- ensure rendering helpers validate paths using normalized variants and improve error messages

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f4246eb548322af15594932fcb491)