### PR TITLE
Add release notes for v0.2.70

### DIFF
--- a/docs/release-notes/v0.2.70.md
+++ b/docs/release-notes/v0.2.70.md
@@ -1,0 +1,11 @@
+# v0.2.70 リリースノート
+
+タグ v0.2.70 では、ファイルパス指定の柔軟性を高めつつ、エクスポート時の標準出力の扱いを見直しました。
+
+## ハイライト
+- **ファイルパスの str サポートを拡充**: エンジンの入出力や per-sheet/per-area 出力先に `str` を直接渡せるよう型定義と正規化を追加し、`process` でも PDF/画像生成を含め `Path` へ統一して処理します。【F:src/exstruct/engine.py†L96-L240】【F:src/exstruct/engine.py†L592-L643】【F:src/exstruct/core/integrate.py†L290-L375】【F:tests/test_engine.py†L164-L243】
+- **副次出力のみの export 実行時に標準出力へ書き出さない挙動に変更**: `output_path` を渡さず `sheets_dir`/`print_areas_dir`/`auto_page_breaks_dir` だけを設定した場合、これらの副次出力に専念し、標準出力へは書き込まなくなりました。【F:src/exstruct/engine.py†L500-L571】
+
+## 互換性と移行
+- 既存の `Path` 指定はそのまま利用できます。`str` を渡す場合でも内部で `Path` に正規化されるため、CLI/アプリケーション双方で同じ挙動になります。【F:src/exstruct/engine.py†L96-L240】【F:src/exstruct/engine.py†L592-L643】【F:src/exstruct/core/integrate.py†L290-L375】
+- 副次出力のみを得たい場合は `output_path=None` のままで問題ありません。標準出力にも流したい場合はこれまで通り `output_path` か `stream` を明示してください。【F:src/exstruct/engine.py†L500-L571】

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - CLI Guide: cli.md
   - Concept / Why ExStruct?: concept.md
   - Release Notes:
+      - v0.2.70: release-notes/v0.2.70.md
       - v0.2.61: release-notes/v0.2.61.md
       - v0.2.60: release-notes/v0.2.60.md
   - Read Me:


### PR DESCRIPTION
## Summary
- add v0.2.70 release notes covering string path support and export output changes
- update the MkDocs navigation to include the new release notes page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940089fde9883229641cf3cdd2507e7)