### PR TITLE
Harden LibreOffice smoke gate: fallback probe on version timeout

### DIFF
--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -1002,3 +1002,30 @@ pairing ルールは次のとおり。
 
 - `tests/core/test_libreoffice_backend.py` に、`_close_stderr_sink()` が一時的な `PermissionError` を retry 後に解消できる regression test を追加する。
 - 同 test file に、stderr log unlink が lock され続けても `_start_soffice_startup_attempt(...)` が `PermissionError` ではなく startup failure を返す regression test を追加する。
+
+## 2026-03-10 PR79 LibreOffice Windows smoke runtime gate hardening
+
+### Background
+
+- Windows CI (`libreoffice-windows-smoke`) can have transiently slow `soffice --version` startup right after Chocolatey install.
+- `tests/conftest.py::_has_libreoffice_runtime()` currently treats any timeout from the version probe as runtime unavailable, which can create a false negative and trip `FORCE_LIBREOFFICE_SMOKE=1`.
+
+### Spec
+
+- `_has_libreoffice_runtime()` keeps strict checks for:
+  - `soffice` executable path existence
+  - bridge-compatible Python resolution
+- Version probe policy is refined:
+  - On `subprocess.TimeoutExpired` from `soffice --version`, do **not** immediately mark runtime unavailable.
+  - Attempt one fallback runtime viability check by launching `LibreOfficeSession.from_env()` and entering/exiting the session.
+  - If fallback session startup succeeds, treat runtime as available (`True`).
+  - If fallback session startup fails with `LibreOfficeUnavailableError`, treat runtime as unavailable (`False`).
+  - Unexpected exceptions from the fallback remain loud (raise) to avoid masking regressions.
+- Existing behavior for `FileNotFoundError`, `OSError`, and `CalledProcessError` in version probe remains `False`.
+
+### Function contracts
+
+- `_has_libreoffice_runtime() -> bool`
+  - Inputs: none (uses env + runtime helpers)
+  - Output: runtime availability decision with timeout fallback behavior above
+  - Side effect: may create a short-lived `LibreOfficeSession` during timeout fallback path

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -755,3 +755,24 @@
   - `python3 -m pytest tests/core/test_libreoffice_backend.py -q` -> `48 passed`
   - `python3 -m pytest tests/test_conftest_libreoffice_runtime.py -q` -> `3 passed`
   - `python3 -m pre_commit run -a` -> `ruff / ruff-format / mypy passed`
+
+## 2026-03-10 PR79 LibreOffice Windows smoke failure investigation
+
+### Planning
+
+- [x] 失敗ログと `tests/conftest.py` の runtime gate を照合し、Windows CI false-negative の経路を特定する
+- [x] `tasks/feature_spec.md` で runtime gate timeout fallback 仕様を明文化する
+- [x] `tests/conftest.py` の LibreOffice 判定を timeout 耐性付きに修正する
+- [x] 回帰テストを追加して timeout fallback 契約を固定する
+- [x] 対象 pytest を実行して挙動を検証する
+
+### Review
+
+- `tests/conftest.py::_has_libreoffice_runtime()` の `soffice --version` probe で `TimeoutExpired` が起きた場合、即 `False` ではなく `LibreOfficeSession.from_env()` の短命セッション probe を 1 回実施するように変更した。
+- fallback session が `LibreOfficeUnavailableError` を返す場合のみ unavailable (`False`) とし、予期しない例外は従来どおり surfacing して fail-fast を維持した。
+- `tests/test_conftest_libreoffice_runtime.py` に timeout fallback の成功/失敗ケース回帰テストを追加し、Windows CI で起きうる初期タイムアウトの false-negative を防ぐ契約を固定した。
+- 検証:
+  - `pytest tests/test_conftest_libreoffice_runtime.py -q` -> `5 passed`
+  - `uv run ruff check tests/conftest.py tests/test_conftest_libreoffice_runtime.py` -> pass
+  - `uv run mypy tests/conftest.py tests/test_conftest_libreoffice_runtime.py` -> pass
+  - `uv run task precommit-run` は pre-commit hook の remote fetch (`astral-sh/ruff-pre-commit`) が `CONNECT tunnel failed, response 403` で失敗（環境制約）

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,14 +101,32 @@ def _has_libreoffice_runtime() -> bool:
             text=True,
             timeout=5.0,
         )
+    except subprocess.TimeoutExpired:
+        return _has_libreoffice_runtime_via_session_probe(
+            libreoffice_module=libreoffice_module,
+            unavailable_error=unavailable_error,
+        )
     except (
         FileNotFoundError,
         OSError,
-        subprocess.TimeoutExpired,
         subprocess.CalledProcessError,
     ):
         return False
     return True
+
+
+def _has_libreoffice_runtime_via_session_probe(
+    *,
+    libreoffice_module: ModuleType,
+    unavailable_error: type[BaseException],
+) -> bool:
+    """Fallback availability probe via a short-lived LibreOffice session."""
+
+    try:
+        with libreoffice_module.LibreOfficeSession.from_env():
+            return True
+    except unavailable_error:
+        return False
 
 
 @lru_cache(maxsize=1)
@@ -200,7 +218,7 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
             pytest.skip(reason)
 
 
-@pytest.fixture(autouse=True)  # type: ignore[misc]
+@pytest.fixture(autouse=True)
 def _skip_com_for_non_com_tests(
     request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_conftest_libreoffice_runtime.py
+++ b/tests/test_conftest_libreoffice_runtime.py
@@ -122,3 +122,112 @@ def test_libreoffice_skip_reason_fails_fast_when_forced(
         conftest._libreoffice_skip_reason()
 
     conftest._has_libreoffice_runtime.cache_clear()
+
+
+def test_has_libreoffice_runtime_timeout_uses_session_fallback_success(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Verify timeout on version probe can recover via session fallback."""
+
+    module_path = Path(__file__).with_name("conftest.py")
+    spec = importlib.util.spec_from_file_location(
+        "tests_runtime_conftest_timeout_success", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load tests/conftest.py")
+    conftest = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(conftest)
+
+    soffice_path = tmp_path / "soffice"
+    soffice_path.write_text("", encoding="utf-8")
+    python_path = tmp_path / "python"
+    python_path.write_text("", encoding="utf-8")
+
+    class _SessionProbe:
+        @classmethod
+        def from_env(cls) -> _SessionProbe:
+            return cls()
+
+        def __enter__(self) -> _SessionProbe:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            _ = exc_type
+            _ = exc
+            _ = tb
+
+    monkeypatch.setattr(
+        conftest,
+        "_load_libreoffice_runtime_module",
+        lambda: SimpleNamespace(
+            LibreOfficeUnavailableError=RuntimeError,
+            LibreOfficeSession=_SessionProbe,
+            _which_soffice=lambda: soffice_path,
+            _resolve_python_path=lambda _path: python_path,
+        ),
+    )
+
+    def _raise_timeout(*args: object, **kwargs: object) -> None:
+        _ = args
+        _ = kwargs
+        raise conftest.subprocess.TimeoutExpired(cmd="soffice --version", timeout=5.0)
+
+    monkeypatch.setattr(conftest.subprocess, "run", _raise_timeout)
+    monkeypatch.delenv("EXSTRUCT_LIBREOFFICE_PATH", raising=False)
+    conftest._has_libreoffice_runtime.cache_clear()
+
+    assert conftest._has_libreoffice_runtime() is True
+
+    conftest._has_libreoffice_runtime.cache_clear()
+
+
+def test_has_libreoffice_runtime_timeout_uses_session_fallback_failure(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Verify timeout fallback returns False when session startup is unavailable."""
+
+    module_path = Path(__file__).with_name("conftest.py")
+    spec = importlib.util.spec_from_file_location(
+        "tests_runtime_conftest_timeout_failure", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load tests/conftest.py")
+    conftest = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(conftest)
+
+    soffice_path = tmp_path / "soffice"
+    soffice_path.write_text("", encoding="utf-8")
+    python_path = tmp_path / "python"
+    python_path.write_text("", encoding="utf-8")
+
+    class ProbeUnavailableError(RuntimeError):
+        """Expected runtime unavailability error for smoke gating."""
+
+    class _SessionProbe:
+        @classmethod
+        def from_env(cls) -> _SessionProbe:
+            raise ProbeUnavailableError("session startup failed")
+
+    monkeypatch.setattr(
+        conftest,
+        "_load_libreoffice_runtime_module",
+        lambda: SimpleNamespace(
+            LibreOfficeUnavailableError=ProbeUnavailableError,
+            LibreOfficeSession=_SessionProbe,
+            _which_soffice=lambda: soffice_path,
+            _resolve_python_path=lambda _path: python_path,
+        ),
+    )
+
+    def _raise_timeout(*args: object, **kwargs: object) -> None:
+        _ = args
+        _ = kwargs
+        raise conftest.subprocess.TimeoutExpired(cmd="soffice --version", timeout=5.0)
+
+    monkeypatch.setattr(conftest.subprocess, "run", _raise_timeout)
+    monkeypatch.delenv("EXSTRUCT_LIBREOFFICE_PATH", raising=False)
+    conftest._has_libreoffice_runtime.cache_clear()
+
+    assert conftest._has_libreoffice_runtime() is False
+
+    conftest._has_libreoffice_runtime.cache_clear()


### PR DESCRIPTION
### Motivation
- Windows CI sometimes times out on `soffice --version` right after LibreOffice install, causing a false-negative runtime detection that raises under `FORCE_LIBREOFFICE_SMOKE=1`.
- The version-probe timeout should not immediately mark the runtime unavailable; a short-lived session probe can confirm actual availability without masking unexpected errors.

### Description
- Update `tests/conftest.py::_has_libreoffice_runtime()` to catch `subprocess.TimeoutExpired` and perform a one-time fallback probe via a new `_has_libreoffice_runtime_via_session_probe()` that calls `LibreOfficeSession.from_env()` for a definitive availability check.
- Add two regression tests in `tests/test_conftest_libreoffice_runtime.py` to cover the timeout-fallback success and failure paths (timeout -> session starts => `True`, timeout -> session raises `LibreOfficeUnavailableError` => `False`).
- Remove an obsolete `# type: ignore[misc]` on the autouse fixture and document the change/spec in `tasks/feature_spec.md` and `tasks/todo.md`.

### Testing
- Ran `pytest tests/test_conftest_libreoffice_runtime.py -q` and observed `5 passed`.
- Ran static checks `uv run ruff check tests/conftest.py tests/test_conftest_libreoffice_runtime.py` and `uv run mypy tests/conftest.py tests/test_conftest_libreoffice_runtime.py`, both of which passed for the modified files.
- `uv run task precommit-run` could not complete in this environment due to a remote fetch failure (`CONNECT tunnel failed, response 403`), which is an environment/network constraint and not a code failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a107087c832289f36c36c3a7cd65)