### PR TITLE
Stabilize Windows LibreOffice smoke runtime detection (prefer soffice.com)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,7 +81,7 @@ jobs:
       PYTHONIOENCODING: "utf-8"
       RUN_LIBREOFFICE_SMOKE: "1"
       FORCE_LIBREOFFICE_SMOKE: "1"
-      EXSTRUCT_LIBREOFFICE_PATH: 'C:\Program Files\LibreOffice\program\soffice.exe'
+      EXSTRUCT_LIBREOFFICE_PATH: 'C:\Program Files\LibreOffice\program\soffice.com'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
@@ -97,10 +97,24 @@ jobs:
         shell: powershell
         run: |
           choco install libreoffice-fresh -y --no-progress
-      - name: Discover LibreOffice bundled Python
+      - name: Discover LibreOffice runtime paths
         shell: powershell
         run: |
           $programDir = Split-Path -Parent $env:EXSTRUCT_LIBREOFFICE_PATH
+          $consoleSoffice = Join-Path $programDir 'soffice.com'
+          $windowedSoffice = Join-Path $programDir 'soffice.exe'
+          if (Test-Path $consoleSoffice) {
+            $selectedSoffice = $consoleSoffice
+          } elseif (Test-Path $windowedSoffice) {
+            $selectedSoffice = $windowedSoffice
+          } else {
+            Write-Host "LibreOffice program directory contents:"
+            Get-ChildItem -Path $programDir -ErrorAction SilentlyContinue | Select-Object Name, FullName
+            throw "Could not find soffice.com or soffice.exe under $programDir"
+          }
+          "EXSTRUCT_LIBREOFFICE_PATH=$selectedSoffice" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Selected LibreOffice executable: $selectedSoffice"
+
           $patterns = @(
             'python.exe',
             'python.bin',
@@ -132,6 +146,9 @@ jobs:
             throw "LibreOffice Python executable not found at $env:EXSTRUCT_LIBREOFFICE_PYTHON_PATH"
           }
           & $env:EXSTRUCT_LIBREOFFICE_PATH --version
+          if ($LASTEXITCODE -ne 0) {
+            throw "LibreOffice version probe failed with exit code $LASTEXITCODE"
+          }
       - name: Run LibreOffice smoke tests
         run: |
           pytest tests/core/test_libreoffice_smoke.py -m libreoffice --maxfail=1 --disable-warnings -q

--- a/src/exstruct/core/libreoffice.py
+++ b/src/exstruct/core/libreoffice.py
@@ -301,10 +301,10 @@ class LibreOfficeSession:
 def _which_soffice() -> Path | None:
     """Return the first discoverable ``soffice`` executable on ``PATH``."""
 
-    for candidate in ("soffice", "soffice.exe"):
+    for candidate in ("soffice", "soffice.com", "soffice.exe"):
         resolved = shutil.which(candidate)
         if resolved:
-            return Path(resolved)
+            return _validated_runtime_path(Path(resolved))
     return None
 
 
@@ -809,10 +809,22 @@ def _reserve_tcp_port() -> int:
 def _validated_runtime_path(path: Path) -> Path:
     """Return a normalized runtime path before it is used in subprocess argv."""
 
+    normalized_path = _prefer_windows_console_soffice(path)
     try:
-        return path.resolve(strict=False)
+        return normalized_path.resolve(strict=False)
     except OSError:
+        return normalized_path
+
+
+def _prefer_windows_console_soffice(path: Path) -> Path:
+    """Prefer ``soffice.com`` when a Windows caller points at ``soffice.exe``."""
+
+    if sys.platform != "win32" or path.name.lower() != "soffice.exe":
         return path
+    console_launcher = path.with_name("soffice.com")
+    if console_launcher.exists():
+        return console_launcher
+    return path
 
 
 def _subprocess_executable_arg(path: Path) -> str:

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -1055,3 +1055,15 @@ pairing ルールは次のとおり。
     2. timeout=30.0 (only after first timeout)
   - Returns `True` when retry probe or fallback session succeeds.
   - Returns `False` on expected runtime-unavailable failures.
+
+
+## 2026-03-11 PR #79 Windows LibreOffice smoke stabilization
+
+- `_validated_runtime_path(path: Path) -> Path`
+  - Windows で `soffice.exe` が指定された場合、同ディレクトリの `soffice.com` が存在すれば `soffice.com` に正規化する。
+  - 非 Windows では入力 path を維持する。
+- `_which_soffice() -> Path | None`
+  - PATH 探索順を `soffice` → `soffice.com` → `soffice.exe` とし、見つかった path は runtime path 正規化を通す。
+- GitHub Actions `libreoffice-windows-smoke`
+  - `EXSTRUCT_LIBREOFFICE_PATH` は `soffice.com` を優先し、存在しない場合のみ `soffice.exe` を fallback とする。
+  - Verify step は `--version` 実行後に `$LASTEXITCODE` を検証し、非ゼロを fail-fast する。

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -801,3 +801,21 @@
   - `uv run ruff check tests/conftest.py tests/test_conftest_libreoffice_runtime.py` -> pass
   - `uv run mypy tests/conftest.py tests/test_conftest_libreoffice_runtime.py` -> pass
   - `uv run task precommit-run` は pre-commit hook remote fetch が `CONNECT tunnel failed, response 403` で失敗（環境制約）
+
+
+## 2026-03-11 PR #79 Windows LibreOffice smoke CI fix
+
+### Planning
+
+- [x] 現行 `libreoffice-windows-smoke` workflow と runtime 正規化実装を確認する
+- [x] Windows で `soffice.com` 優先となるよう runtime path 正規化と workflow を修正する
+- [x] 回帰テストを追加し、対象 pytest を実行して検証する
+- [x] 変更内容を自己レビューし、commit/PR メッセージを作成する
+
+### Review
+
+- `src/exstruct/core/libreoffice.py` で runtime path 正規化時に Windows の `soffice.exe` を `soffice.com` 優先へ自動変換する helper を追加した。
+- `src/exstruct/core/libreoffice.py` の `_which_soffice()` は `soffice.com` を探索候補に追加し、検出 path を正規化して返すようにした。
+- `.github/workflows/pytest.yml` の Windows smoke job は `soffice.com` を既定にしつつ、discover step で `.com` 優先 / `.exe` fallback を明示し `EXSTRUCT_LIBREOFFICE_PATH` を再設定するよう変更した。
+- 同 workflow の verify step で `--version` 実行後 `$LASTEXITCODE` を確認し、非ゼロを即失敗にするようにした。
+- `tests/core/test_libreoffice_backend.py` に runtime path 正規化の Windows/非 Windows 回帰テストを追加した。

--- a/tests/core/test_libreoffice_backend.py
+++ b/tests/core/test_libreoffice_backend.py
@@ -37,6 +37,7 @@ from exstruct.core.libreoffice import (
     _run_bridge_extract_subprocess,
     _run_bridge_probe_subprocess,
     _start_soffice_startup_attempt,
+    _validated_runtime_path,
 )
 from exstruct.core.ooxml_drawing import (
     DrawingConnectorRef,
@@ -1957,6 +1958,51 @@ def test_libreoffice_session_reports_both_startup_attempt_failures(
     assert cleaned_paths == [created_dir]
     assert session._soffice_process is None
     assert session._temp_profile_dir is None
+
+
+def test_validated_runtime_path_prefers_windows_console_soffice(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Verify that Windows `soffice.exe` paths normalize to `soffice.com` when present."""
+
+    monkeypatch.setattr("exstruct.core.libreoffice.sys.platform", "win32")
+
+    base_path = Path("C:/LibreOffice/program/soffice.exe")
+
+    def _fake_exists(self: Path) -> bool:
+        return self.name.lower() == "soffice.com"
+
+    monkeypatch.setattr(Path, "exists", _fake_exists)
+
+    assert _validated_runtime_path(base_path).name.lower() == "soffice.com"
+
+
+def test_validated_runtime_path_keeps_windows_soffice_exe_without_console_variant(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Verify that Windows runtime normalization keeps `.exe` when `.com` is absent."""
+
+    monkeypatch.setattr("exstruct.core.libreoffice.sys.platform", "win32")
+
+    base_path = Path("C:/LibreOffice/program/soffice.exe")
+
+    monkeypatch.setattr(Path, "exists", lambda _self: False)
+
+    assert _validated_runtime_path(base_path).name.lower() == "soffice.exe"
+
+
+def test_validated_runtime_path_keeps_non_windows_runtime(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Verify that non-Windows runtime normalization does not rewrite executable names."""
+
+    monkeypatch.setattr("exstruct.core.libreoffice.sys.platform", "linux")
+
+    base_path = Path("/opt/libreoffice/program/soffice.exe")
+
+    monkeypatch.setattr(Path, "exists", lambda _self: True)
+
+    assert _validated_runtime_path(base_path).name.lower() == "soffice.exe"
 
 
 def test_resolve_python_path_prefers_override(


### PR DESCRIPTION
### Motivation
- Windows CI smoke tests were failing because the runtime probe treated the LibreOffice runtime as unavailable when `soffice.exe` was used for CLI automation.  
- On Windows the console launcher `soffice.com` is the intended entry for scripted/console usage and avoids async/transfer behavior exhibited by `soffice.exe`.  
- Make the Windows smoke job and library runtime checks robust to cold-install jitter and the `.exe` vs `.com` launcher mismatch so smoke tests can reach the UNO bridge stage.

### Description
- GitHub Actions: changed `libreoffice-windows-smoke` default `EXSTRUCT_LIBREOFFICE_PATH` to point at `soffice.com`, added a discovery step that selects `soffice.com` when present and falls back to `soffice.exe`, and made the verify step inspect `$LASTEXITCODE` after `--version` to fail-fast on non-zero exit codes (`.github/workflows/pytest.yml`).
- Runtime normalization: updated `_which_soffice()` to include `soffice.com` as a lookup candidate and normalize discovered executables through `_validated_runtime_path()` (`src/exstruct/core/libreoffice.py`).
- Automatic preference: added `_prefer_windows_console_soffice()` and wired it into `_validated_runtime_path()` so a Windows `soffice.exe` input will be rewritten to `soffice.com` when that console launcher exists (`src/exstruct/core/libreoffice.py`).
- Tests & docs: added regression unit tests that cover Windows/non-Windows runtime normalization behavior (`tests/core/test_libreoffice_backend.py`) and documented the contract/plan in `tasks/feature_spec.md` and `tasks/todo.md`.

### Testing
- Ran `pytest tests/core/test_libreoffice_backend.py -q -k "validated_runtime_path"` which exercised the new tests: `3 passed, 48 deselected`.
- Verified syntax/compilation with `python -m py_compile src/exstruct/core/libreoffice.py tests/core/test_libreoffice_backend.py` which succeeded.
- Ran static checks: `uv run ruff check src/exstruct/core/libreoffice.py tests/core/test_libreoffice_backend.py` passed and `uv run ruff format` was applied and re-checked; formatting and lint checks passed for the modified files.
- `uv run task precommit-run` could not complete in this environment because pre-commit attempted to fetch remote hooks and failed due to network restriction (`CONNECT tunnel failed, response 403`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0dc86c3548322adccc5108be644a4)