### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented in this file. This changelog 
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-03-12
+
+### Added
+
+- Added a dedicated GitHub Actions Windows LibreOffice smoke job on `windows-2025` that installs `libreoffice-fresh`, discovers runtime paths, and runs `tests/core/test_libreoffice_smoke.py` with `RUN_LIBREOFFICE_SMOKE=1`.
+- Added Windows-focused regression coverage for LibreOffice runtime normalization, bundled Python discovery, bridge subprocess environment setup, and smoke-gate timeout fallback behavior.
+
+### Changed
+
+- Updated README, README.ja, and test requirements to document LibreOffice smoke coverage on both Linux and Windows CI.
+- Changed LibreOffice bridge subprocess execution on Windows so probe, handshake, and extraction runs use the runtime directory as `cwd` and prepend runtime paths to `PATH`.
+
+### Fixed
+
+- Fixed Windows LibreOffice runtime discovery to prefer `soffice.com` when it is available and to detect bundled LibreOffice Python under `python-core-*` layouts.
+- Fixed false-negative Windows LibreOffice smoke gating by retrying slow `soffice --version` probes and falling back to a short-lived session probe before treating the runtime as unavailable.
+
 ## [0.6.0] - 2026-03-06
 
 ### Added

--- a/docs/release-notes/v0.6.1.md
+++ b/docs/release-notes/v0.6.1.md
@@ -1,0 +1,34 @@
+# v0.6.1 Release Notes
+
+This patch release hardens Windows LibreOffice smoke coverage and runtime
+resolution for the `libreoffice` extraction path.
+
+## Highlights
+
+- Added a dedicated Windows GitHub Actions LibreOffice smoke job:
+  - runs on `windows-2025`
+  - installs `libreoffice-fresh`
+  - discovers `EXSTRUCT_LIBREOFFICE_PATH` and bundled LibreOffice Python
+  - runs `tests/core/test_libreoffice_smoke.py -m libreoffice` with
+    `RUN_LIBREOFFICE_SMOKE=1`
+- Improved Windows runtime discovery:
+  - `soffice.com` is now preferred over `soffice.exe` when available
+  - bundled LibreOffice Python detection now covers `python-core-*` layouts
+- Hardened LibreOffice bridge subprocess startup on Windows:
+  - bridge probe, handshake, and extraction now run from the runtime Python
+    directory
+  - the runtime directory is prepended to `PATH` for UNO import and DLL
+    resolution
+- Reduced smoke-gate false negatives:
+  - slow `soffice --version` probes are retried with a longer timeout
+  - if version probing still times out, the smoke gate falls back to a
+    short-lived LibreOffice session probe before marking the runtime
+    unavailable
+- Added regression tests for Windows runtime normalization, bundled Python
+  discovery, bridge subprocess environment handling, and timeout fallback.
+
+## Notes
+
+- This is a reliability-focused patch release for Windows LibreOffice CI and
+  runtime detection.
+- No public API or output schema changes were introduced in this release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - MCP Server: mcp.md
   - Concept / Why ExStruct?: concept.md
   - Release Notes:
+      - v0.6.1: release-notes/v0.6.1.md
       - v0.6.0: release-notes/v0.6.0.md
       - v0.5.3: release-notes/v0.5.3.md
       - v0.5.2: release-notes/v0.5.2.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "exstruct"
-version = "0.6.0"
+version = "0.6.1"
 description = "Excel to structured JSON (tables, shapes, charts) for LLM/RAG pipelines"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tasks/feature_spec.md
+++ b/tasks/feature_spec.md
@@ -1,5 +1,27 @@
 # Feature Spec
 
+## 2026-03-12 v0.6.1 release notes and changelog
+
+### Issue
+
+- PR #79 と、そのマージ前に同ブランチへ積まれた Windows LibreOffice smoke stabilization 変更を `v0.6.1` としてパッチリリースする。
+- 公開用の release notes と `CHANGELOG.md` がまだ `v0.6.0` のままで、Windows smoke job 追加と runtime stabilization の内容が反映されていない。
+
+### Documentation contract
+
+- `v0.6.1` のリリース文書は、`v0.6.0..314ac86` の差分に基づいて要点を整理する。
+- 主題は次の 3 点に絞る。
+  - GitHub Actions への Windows LibreOffice smoke job 追加
+  - Windows 向け LibreOffice runtime/path discovery の安定化
+  - smoke runtime gate の false-negative 抑制
+- 既存の `v0.6.0` release notes と重複して LibreOffice mode 全体を再説明しない。今回は patch release の差分だけを書く。
+
+### Verification
+
+- `CHANGELOG.md` に `## [0.6.1] - 2026-03-12` を追加する。
+- `docs/release-notes/v0.6.1.md` を追加する。
+- `mkdocs.yml` の Release Notes nav に `v0.6.1` を追加する。
+
 ## 2026-03-10 PR #76 review + Codacy follow-up
 
 ### Issue

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,26 @@
 # Todo
 
+## 2026-03-12 v0.6.1 release notes and changelog
+
+### Planning
+
+- [x] `v0.6.0..314ac86` の差分を確認し、`v0.6.1` で告知する変更点を抽出する
+- [x] `tasks/feature_spec.md` に今回のリリース文書方針を記録する
+- [x] `CHANGELOG.md` に `v0.6.1` エントリを追加する
+- [x] `docs/release-notes/v0.6.1.md` を作成し、patch release の要点をまとめる
+- [x] `mkdocs.yml` の release notes nav を更新する
+- [x] 変更差分を確認し、最低限の文書整合性検証を行う
+
+### Review
+
+- `CHANGELOG.md` には `2026-03-12` 付けで `0.6.1` セクションを追加し、PR #79 系列の差分を `Added / Changed / Fixed` に整理した。
+- `docs/release-notes/v0.6.1.md` を新規追加し、Windows LibreOffice smoke job 追加、runtime/path discovery 安定化、bridge subprocess の Windows 対応、smoke gate false-negative 抑制を patch release の要点として記載した。
+- `mkdocs.yml` の Release Notes nav に `v0.6.1` を追加し、公開サイトから新しい release notes に遷移できるようにした。
+- 検証:
+  - `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('mkdocs.yml').read_text(encoding='utf-8')); print('yaml-ok')"` -> `yaml-ok`
+  - `git diff --check` -> 空白エラーなし。LF/CRLF の警告のみ
+  - 目視確認で `CHANGELOG.md` 冒頭、`docs/release-notes/v0.6.1.md`、`mkdocs.yml` の nav 追加を確認した
+
 ## 2026-03-10 PR #76 review + Codacy follow-up
 
 ### Planning


### PR DESCRIPTION
## Summary
- bump the package version to v0.6.1
- add v0.6.1 changelog and release notes for the PR #79 Windows LibreOffice smoke follow-up
- publish the new release note page in the MkDocs navigation

## Verification
- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('mkdocs.yml').read_text(encoding='utf-8')); print('yaml-ok')"
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows GitHub Actions smoke job for enhanced LibreOffice testing on Windows.
  * Added Windows-specific regression test coverage.

* **Bug Fixes**
  * Improved Windows runtime discovery and bundled Python detection.
  * Enhanced smoke-gate reliability with retry logic and fallback probes.

* **Documentation**
  * Updated CHANGELOG and release notes for v0.6.1.

* **Chores**
  * Bumped project version to 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->