### PR TITLE
Find LibreOffice's bundled Python inside a macOS app bundle

### DIFF
--- a/src/exstruct/core/libreoffice.py
+++ b/src/exstruct/core/libreoffice.py
@@ -800,6 +800,9 @@ def _resolve_python_path(soffice_path: Path) -> Path | None:
     return None
 
 
+_MACOS_BUNDLE_MACOS_DIR = Path("/Applications/LibreOffice.app/Contents/MacOS")
+
+
 def _soffice_program_dirs(soffice_path: Path) -> tuple[Path, ...]:
     """Return candidate LibreOffice program directories for the given ``soffice`` path."""
 
@@ -810,6 +813,18 @@ def _soffice_program_dirs(soffice_path: Path) -> tuple[Path, ...]:
         return tuple(program_dirs)
     if resolved_parent not in program_dirs:
         program_dirs.append(resolved_parent)
+    # macOS keeps soffice in Contents/MacOS but the bundled Python in the sibling
+    # Contents/Resources, so the executable's own dir never finds it. Homebrew
+    # compounds this by putting a bash wrapper on PATH that execs into the bundle,
+    # leaving the resolved path outside the bundle entirely -- hence the fixed
+    # bundle location as a last resort.
+    if sys.platform == "darwin":
+        for parent in (*program_dirs, _MACOS_BUNDLE_MACOS_DIR):
+            if parent.name != "MacOS":
+                continue
+            resources_dir = parent.parent / "Resources"
+            if resources_dir.is_dir() and resources_dir not in program_dirs:
+                program_dirs.append(resources_dir)
     return tuple(program_dirs)
 
 

--- a/tests/core/test_libreoffice_macos_paths.py
+++ b/tests/core/test_libreoffice_macos_paths.py
@@ -1,0 +1,63 @@
+"""macOS keeps LibreOffice's bundled Python outside the soffice executable's dir."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from exstruct.core import libreoffice
+
+
+def _fake_bundle(root: Path) -> tuple[Path, Path]:
+    """Build a minimal LibreOffice.app layout and return (soffice, python)."""
+    macos_dir = root / "LibreOffice.app" / "Contents" / "MacOS"
+    resources_dir = root / "LibreOffice.app" / "Contents" / "Resources"
+    macos_dir.mkdir(parents=True)
+    resources_dir.mkdir(parents=True)
+    soffice = macos_dir / "soffice"
+    python = resources_dir / "python"
+    soffice.write_text("#!/bin/sh\n")
+    python.write_text("#!/bin/sh\n")
+    return soffice, python
+
+
+def test_program_dirs_include_the_sibling_resources_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(libreoffice.sys, "platform", "darwin")
+    soffice, python = _fake_bundle(tmp_path)
+
+    dirs = libreoffice._soffice_program_dirs(soffice)
+
+    assert python.parent in dirs
+    candidates = [c for d in dirs for c in libreoffice._bundled_python_candidates(d)]
+    assert python in candidates
+
+
+def test_program_dirs_fall_back_to_the_bundle_for_a_homebrew_wrapper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Homebrew puts a bash wrapper on PATH, so the resolved path leaves the bundle."""
+    monkeypatch.setattr(libreoffice.sys, "platform", "darwin")
+    _, python = _fake_bundle(tmp_path)
+    monkeypatch.setattr(
+        libreoffice, "_MACOS_BUNDLE_MACOS_DIR", python.parent.parent / "MacOS"
+    )
+    wrapper_dir = tmp_path / "command-wrappers"
+    wrapper_dir.mkdir()
+    wrapper = wrapper_dir / "soffice"
+    wrapper.write_text("#!/bin/bash\n")
+
+    dirs = libreoffice._soffice_program_dirs(wrapper)
+
+    assert python.parent in dirs
+
+
+def test_program_dirs_stay_unchanged_off_macos(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(libreoffice.sys, "platform", "linux")
+    soffice, python = _fake_bundle(tmp_path)
+
+    assert python.parent not in libreoffice._soffice_program_dirs(soffice)


### PR DESCRIPTION
### The bug

`_soffice_program_dirs` only ever looks in soffice's own directory. That holds on Windows and Linux, but a macOS app bundle keeps soffice in `Contents/MacOS` and the bundled Python in the sibling `Contents/Resources`, so discovery never finds it:

```console
$ exstruct sample/basic/sample.xlsx --mode libreoffice
[libreoffice_unavailable] LibreOffice runtime is unavailable.
  (LibreOfficeUnavailableError('LibreOffice runtime is unavailable:
   compatible Python runtime was not found.'))
```

```
/Applications/LibreOffice.app/Contents/MacOS/soffice        <- _which_soffice finds this
/Applications/LibreOffice.app/Contents/Resources/python     <- bundled Python lives here
```

Homebrew compounds it: the `soffice` it puts on `PATH` is a bash wrapper that `exec`s into the app bundle, so `shutil.which` resolves to a Caskroom `command-wrappers` directory outside the bundle entirely — hence the fallback to the standard bundle location as well.

After the change, discovery succeeds from a bare `PATH` lookup:

```python
>>> p = _which_soffice()
>>> _soffice_program_dirs(p)
('/opt/homebrew/Caskroom/libreoffice/26.2.5/.homebrew-command-wrappers',
 '/Applications/LibreOffice.app/Contents/Resources')
>>> _resolve_python_path(p)
PosixPath('/Applications/LibreOffice.app/Contents/Resources/python')
```

### Please read this before merging

**This fixes discovery only — it does not make `--mode libreoffice` work on macOS.** I want to be straight about that rather than have it look like a working path.

Once found, the bundled interpreter still cannot be spawned from outside LibreOffice. It dies instantly, and the crash report gives the reason:

```
exception:   {'type': 'EXC_CRASH', 'signal': 'SIGKILL (Code Signature Invalid)'}
termination: {"namespace": "CODESIGNING", "code": 4,
              "indicator": "Launch Constraint Violation"}
```

That is a macOS launch constraint, not a packaging accident on my machine. I ruled the alternatives out: the signature verifies (`codesign -v` clean), there is no `com.apple.quarantine` attribute, the binary is arm64 on an arm64 host, and it reproduces identically on a freshly reinstalled LibreOffice 26.2.5. `soffice` itself runs fine — only direct invocation of the nested Python is refused.

`_system_python_candidates` is the remaining fallback, but a Homebrew LibreOffice ships no `uno` module for a system Python, so it finds nothing either.

So: this patch turns a silent mis-detection into a correct one, which seemed worth having on its own, and the tests pin the platform layout. But if you would rather gate the mode off on darwin with a clear message than let it get one step further and fail elsewhere, say so and I will close this — or rework it that way, whichever you prefer.

### Tests

`tests/core/test_libreoffice_macos_paths.py` builds a fake bundle under `tmp_path` and covers the sibling-`Resources` case, the Homebrew-wrapper fallback, and that non-darwin behaviour is unchanged. All three patch `sys.platform`, so they run anywhere.

927 tests pass (3 new), `mypy --strict` and `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LibreOffice integration on macOS by reliably locating bundled Python resources.
  * Added support for LibreOffice installations using standard application bundles and Homebrew wrappers.
  * Preserved platform-specific behavior so Linux installations are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

## Correction (added after further investigation)

Two things in the note above are wrong, and the second one matters a lot. Sorry for the noise — I would rather correct it in place than leave it standing.

**1. Version.** This reproduces on **26.8.0.3**, not 26.2.5. A `brew reinstall --cask libreoffice` moved the install from 26.2.5 to 26.8.0.3 (and the bundled Python from 3.12 to 3.13) mid-investigation; the constraint is present in both.

**2. "The mode remains unavailable there" is not true — there is a working route on macOS, and I have run it.**

First, the root cause, which I could not identify before. It is a **parent launch constraint that LibreOffice itself declares**, slot 9 of the signature superblob (magic `fade8181`). Decoded DER:

```
{ ccat: 0, comp: 1,
  reqs: { signing-identifier: "org.libreoffice.script",
          team-identifier:    "7P5S3ZLCN7" },
  vers: 1 }
```

So the immediate parent must be a TDF-signed binary with identifier `org.libreoffice.script` — i.e. `soffice`. That is why `codesign -d --verbose=6` shows nothing useful; at every verbosity it only prints "Has Parent Launch Constraints", and the detail has to be read out of the raw `LC_CODE_SIGNATURE` blob. The same constraint is on `bin/python3.13`, `MacOS/uno`, `gengal`, `opencltest`, `regview` and `xpdfimport` — but **not** on `soffice` or `unopkg`.

It arrived deliberately: commit [22ab2bec](https://github.com/LibreOffice/core/commit/22ab2bec717b44e85e110cd67175c2f3599264c2) "mac: add parent launch-constraint to packaged framework/helpers except for unopkg" (2025-05-27), with [tdf#167080](https://www.mail-archive.com/libreoffice@lists.freedesktop.org/msg357144.html) (2025-07-04, backported to libreoffice-25-2) fixing the plist so it actually enforces. Every TDF-signed release since then carries it, so the official dmg and both casks behave identically. Nothing is misconfigured on my machine.

**The route that works:** run the bridge *inside* soffice via the Python script provider, rather than exec'ing the bundled interpreter. Launch constraints gate `exec`, not `dlopen` — `libpythonloaderlo.dylib` dlopens `libpyuno.dylib` and the framework's libpython straight into soffice, so the constraint never applies.

I put `_libreoffice_bridge.py` in a throwaway profile's `user/Scripts/python/`, changed **only** `_resolve_context()` (`_libreoffice_bridge.py:219-238`) to `uno.getComponentContext()`, and left `_load_document`, `_extract_draw_page_payload`, `_extract_chart_payload` and `_close_document` (`:241-355`) untouched:

```console
$ soffice --headless --nologo --norestore --nolockcheck \
    -env:UserInstallation=file://<tmp-profile> \
    'vnd.sun.star.script:exbridge.py$run_in_office?language=Python&location=user'
```

Full draw-page payload, ~3 s including launch — 33 shapes on `sample/flowchart/sample-shape-connector.xlsx`, connectors flagged, `sys.executable == /Applications/LibreOffice.app/Contents/MacOS/soffice`, Python 3.13.15.

One design consequence: **a forwarded script URL does not execute.** If a listener is already up, a second `soffice ... 'vnd.sun.star.script:...'` returns 0 immediately and the provider never sees a `getScript` (plain `--convert-to` forwards fine, so it is specific to script URLs). So the persistent `--accept` listener at `libreoffice.py:593-616` would have to give way to one headless `soffice` per workbook — roughly 3 s per file instead of 3 s per session — with parameters passed via a request file rather than env vars.

**Where that leaves this PR.** The discovery fix here is still correct on its own terms, but it repairs `_resolve_python_path()` — the very function a proper macOS fix would delete. So I am happy for you to close this, and I would rather you did than merge something that entrenches the wrong design. If you would like the script-provider route as a real PR instead, say the word and I will put one together; if you would rather gate the mode off on darwin with a clear message, that is a smaller change and I can do that too. Your call — I do not want to guess at the architecture you want.
